### PR TITLE
生成されたファイルがコンパイルできない問題

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@openapitools/openapi-generator-cli": {
-      "version": "1.0.2-4.2.0",
-      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-1.0.2-4.2.0.tgz",
-      "integrity": "sha512-rkr7fDUyU06wjszO/chRVtITS5dN4FFg4i6/zuLIVMKcpGNIq2vjw2NJhNG11vjA/aBnnFMFrvC4z99O5Wsuiw==",
+      "version": "1.0.8-4.2.2",
+      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-1.0.8-4.2.2.tgz",
+      "integrity": "sha512-K14xUl5Cc2Epm5hoclvi1KGANy9SCSWddEZCLk9Ij0v0ujbLtK1bMOkrjCOz0ADxdb0Vfsc6T6EE3G3lmBrOCQ==",
       "dev": true
     },
     "@types/caseless": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "devDependencies": {
-    "@openapitools/openapi-generator-cli": "^1.0.2-4.2.0",
+    "@openapitools/openapi-generator-cli": "^1.0.8-4.2.2",
     "@types/node": "^12.12.5",
     "@types/prompts": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^2.5.0",


### PR DESCRIPTION
# なぜこの変更が必要なのですか？
[コンパイルが失敗](https://github.com/ksoda/freeeapi-typescript-helper/runs/356705851)してしまう
```bash
npm run apibuild && npm run tsc
```

```shell-session
❯ uname -a
Linux ken-ThinkPad-E490 5.3.0-24-generic #26-Ubuntu SMP Thu Nov 14 01:33:18 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux

❯ node -v
v10.16.0
```

<details>
<summary>log</summary>

```
npm WARN lifecycle The node binary used for scripts is /home/ken/.asdf/shims/node but npm is using /home/ken/.asdf/installs/nodejs/10.16.0/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.

> freee-openapi-typescript@1.0.0 tsc /home/ken/dev/freeeapi-typescript-helper
> tsc

src/freeeapi/model/badRequestErrorErrors.ts:13:16 - error TS1005: ',' expected.

13 import { Array | string } from './array | string';
                  ~

src/freeeapi/model/badRequestErrorErrors.ts:13:25 - error TS1128: Declaration or statement expected.

13 import { Array | string } from './array | string';
                           ~

src/freeeapi/model/badRequestErrorErrors.ts:13:32 - error TS1005: ';' expected.

13 import { Array | string } from './array | string';
                                  ~~~~~~~~~~~~~~~~~~

src/freeeapi/model/badRequestNotFoundErrorErrors.ts:13:16 - error TS1005: ',' expected.

13 import { Array | string } from './array | string';
                  ~

src/freeeapi/model/badRequestNotFoundErrorErrors.ts:13:25 - error TS1128: Declaration or statement expected.

13 import { Array | string } from './array | string';
                           ~

src/freeeapi/model/badRequestNotFoundErrorErrors.ts:13:32 - error TS1005: ';' expected.

13 import { Array | string } from './array | string';
                                  ~~~~~~~~~~~~~~~~~~

src/freeeapi/model/internalServerErrorErrors.ts:13:16 - error TS1005: ',' expected.

13 import { Array | string } from './array | string';
                  ~

src/freeeapi/model/internalServerErrorErrors.ts:13:25 - error TS1128: Declaration or statement expected.

13 import { Array | string } from './array | string';
                           ~

src/freeeapi/model/internalServerErrorErrors.ts:13:32 - error TS1005: ';' expected.

13 import { Array | string } from './array | string';
                                  ~~~~~~~~~~~~~~~~~~


Found 9 errors.

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! freee-openapi-typescript@1.0.0 tsc: `tsc`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the freee-openapi-typescript@1.0.0 tsc script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/ken/.npm/_logs/2019-12-19T16_05_48_811Z-debug.log
```
</details>

# どのように問題に対処しますか？
npm package を更新する
```bash
npx npm-check-updates -u @openapitools/openapi-generator-cli
```

# 副作用はありますか？
要調査。E2E testing で動作を担保してから Merge したい。